### PR TITLE
add stack to policy name

### DIFF
--- a/kinesis/EC2InstanceKinesisAgent.yml
+++ b/kinesis/EC2InstanceKinesisAgent.yml
@@ -165,7 +165,7 @@ Resources:
             Action:
               - "cloudwatch:PutMetricData"
             Resource: '*'
-      PolicyName: "kinesisds-put-records-policy"
+      PolicyName: !Sub ${AWS::StackName}-firehose-put-records-policy"
       Roles:
         - !Ref LnDataProducerRole
 


### PR DESCRIPTION
so that there is no naming conflict between two instances of the stack template